### PR TITLE
support for OpenSession command

### DIFF
--- a/scripts/packet.js
+++ b/scripts/packet.js
@@ -15,6 +15,7 @@ define(['./data-factory'], function (dataFactory) {
         createInitEventAck,
         createInitEventRequest,
         createCmdRequest,
+        createOpenSessionAck,
         createStartDataPacket,
         createDataPacket,
         createEndDataPacket,
@@ -80,6 +81,15 @@ define(['./data-factory'], function (dataFactory) {
                 data.getDword(10)
             ]
         };
+    };
+
+    parsers[types.cmdRequest] = function (data) {
+      return {
+        dataPhaseInfo: data.getDword(0),
+        opCode: data.getWord(4),
+        sessionId: data.getDword(6),
+        transactionId: data.getDword(10),
+      };
     };
 
     parsers[types.cmdResponse] = function (data) {
@@ -239,6 +249,21 @@ define(['./data-factory'], function (dataFactory) {
         return data;
     };
 
+    createOpenSessionAck = function () {
+        // TODO(gswirski): this should probably be a generic CmdResponse handler
+        //
+        // For now I hardcoded what I saw in my Wireshark session. I don't
+        // understand why the length is 14 bytes but the camera sends only 10.
+        // Might be worth experimenting with more zeros at the end, but for now,
+        // achievement unlocked. Camera sends the next command: getDeviceInfo
+        var data = dataFactory.create();
+        data.setDword(0, 14);
+        data.appendDword(7);
+        data.appendDword(8193);
+        data.appendWord(0);
+        return data;
+    };
+
     createStartDataPacket = function (size) {
         var data = dataFactory.create();
 
@@ -282,6 +307,7 @@ define(['./data-factory'], function (dataFactory) {
         createInitEventAck: {value: createInitEventAck},
         createInitEventRequest: {value: createInitEventRequest},
         createCmdRequest: {value: createCmdRequest},
+        createOpenSessionAck: {value: createOpenSessionAck},
         createStartDataPacket: {value: createStartDataPacket},
         createDataPacket: {value: createDataPacket},
         createEndDataPacket: {value: createEndDataPacket},

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -16,6 +16,7 @@ define(['./packet','./connection-settings', './main-loop', './data-factory'], fu
         socket.on('data', function(data) {
 
             let packets = packet.parsePackets(dataFactory.create(data));
+            console.log("received PTP/IP packets", packets);
             if (packets.length === 1 && packets[0].type === packet.types.initCommandRequest) {
                 console.log("Received Init_Command_Request", packets[0]);
                 let sessionId = Math.floor(Math.random() * 4294967295/2);
@@ -30,6 +31,13 @@ define(['./packet','./connection-settings', './main-loop', './data-factory'], fu
                 let data = packet.createInitEventAck(sessionId);
                 socket.write(data.buffer);
                 console.log("Sending Init_Event_Ack in response", sessionId);
+            } else if (packets.length === 1 && packets[0].type === packet.types.cmdRequest) {
+                console.log("Received Open_Session", packets[0]);
+                let data = packet.createOpenSessionAck()
+                socket.write(data.buffer)
+                console.log("Sending Open_Session_Response in response");
+            } else {
+                console.log("Received unknown packets", packets);
             }
             // Write the data back to all the connected, the client will receive it as data from the server
         });


### PR DESCRIPTION
Not the cleanest implementation. I just wanted to see if copying data blindly from Wireshark would work - it seems it does. ImagineEdge requested device into instead of disconnecting immediately.

Also, I realized after sending this pull request that my createOpenSessionAck method is actually a well-formatted Operation Response packet according to Wireshark. length == 14 includes header (length field itself) so all starts making sense now.